### PR TITLE
Add `Wangkanai.Planet.Common.Tests` project with initial xUnit test s…

### DIFF
--- a/Common/tests/UnitTest1.cs
+++ b/Common/tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+namespace Wangkanai.Planet.Common.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+        Assert.True(true);
+    }
+}

--- a/Common/tests/Wangkanai.Planet.Common.Tests.csproj
+++ b/Common/tests/Wangkanai.Planet.Common.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+
+    <!--
+    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    To enable the Microsoft Testing Platform native command line experience, add property:
+      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/Common/tests/xunit.runner.json
+++ b/Common/tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/Planet.slnx
+++ b/Planet.slnx
@@ -19,6 +19,7 @@
   </Folder>
   <Folder Name="/Common/">
     <Project Path="Common\src\Domain\Wangkanai.Planet.Common.Domain.csproj" Type="Classic C#" />
+    <Project Path="Common\tests\Wangkanai.Planet.Common.Tests.csproj" Type="Classic C#" />
     <File Path="Common\Directory.Build.props" />
   </Folder>
   <Folder Name="/Engine/">


### PR DESCRIPTION

This pull request introduces a new unit testing project for the `Wangkanai.Planet.Common` module. It includes the addition of a test class, project configuration for xUnit, and updates to the solution file to integrate the new test project.

### Addition of Unit Testing Framework:

* [`Common/tests/UnitTest1.cs`](diffhunk://#diff-fe76fc59fc946b84dea5ef5f31588dea479ab56cf92ae0c0f82601507c59a620R1-R10): Added a basic unit test class `UnitTest1` with a single test method `Test1` that asserts `true`.
* [`Common/tests/xunit.runner.json`](diffhunk://#diff-02a2d8ed4921003b4704c95f7bf20bd022b0f1681f2efbfdce3141d4caff0c3aR1-R3): Added a JSON configuration file for the xUnit test runner, referencing the xUnit schema.

### Project and Solution Configuration:

* [`Common/tests/Wangkanai.Planet.Common.Tests.csproj`](diffhunk://#diff-83be47a2178373da9fa588560a42d41bf0eb07a1e546c8e030e2b7b562881124R1-R22): Created a new `.csproj` file for the test project, including properties for output type and xUnit runner configuration.
* [`Planet.slnx`](diffhunk://#diff-a5072e017d1a49e3f214149ec9712d9550a77bee47881a24422716c6fd39d528R22): Updated the solution file to include the new test project under the `/Common/` folder.