### PR TITLE
Add theme parameter to user creation in UserSeed

### DIFF
--- a/Portal/src/Application/Identity/UserSeed.cs
+++ b/Portal/src/Application/Identity/UserSeed.cs
@@ -10,7 +10,7 @@ internal static class UserSeed
 {
 	internal static List<PlanetUser> Users =>
 	[
-		Create(1, "sarin@wangkanai.com", "P@ssw0rd", "Sarin", "Na Wangkanai"),
+		Create(1, "sarin@wangkanai.com", "P@ssw0rd", "Sarin", "Na Wangkanai", Theme.Dark),
 		Create(2, "admin@demo.com", "P@ssw0rd", "Admin", "Demo"),
 		Create(3, "moderator@demo.com", "P@ssw0rd", "Moderator", "Demo"),
 		Create(4, "editor@demo.com", "P@ssw0rd", "Editor", "Demo"),
@@ -20,7 +20,7 @@ internal static class UserSeed
 
 	private static PasswordHasher<PlanetUser> Hasher => new();
 
-	private static PlanetUser Create(int id, string email, string password, string firstname, string lastname)
+	private static PlanetUser Create(int id, string email, string password, string firstname, string lastname, Theme theme = Theme.System)
 		=> new()
 		   {
 			   Id                 = id,
@@ -32,5 +32,6 @@ internal static class UserSeed
 			   PasswordHash       = Hasher.HashPassword(null!, password),
 			   Firstname          = firstname,
 			   Lastname           = lastname,
+			   Theme              = theme
 		   };
 }


### PR DESCRIPTION
This pull request updates the `UserSeed` class in `Portal/src/Application/Identity/UserSeed.cs` to include a new `Theme` property for `PlanetUser` objects. The changes ensure that the `Theme` property is set during user creation, with a default value of `Theme.System`.

### Enhancements to `UserSeed` functionality:

* Updated the `Create` method to accept an additional `Theme` parameter, defaulting to `Theme.System`, allowing users to have a predefined theme.
* Modified the `Users` list to include the `Theme` property for the first user (`sarin@wangkanai.com`), explicitly setting it to `Theme.Dark`.
* Added initialization of the `Theme` property in the `PlanetUser` object creation process within the `Create` method.