### PR TITLE
Add MbTiles support with interfaces and enums for tile management

### DIFF
--- a/Planet.slnx
+++ b/Planet.slnx
@@ -59,6 +59,7 @@
   </Folder>
   <Folder Name="/Spatial/">
     <Project Path="Spatial\src\Abstractions\Wangkanai.Planet.Spatial.Abstractions.csproj" Type="Classic C#" />
+    <Project Path="Spatial\src\MbTiles\Wangkanai.Planet.Spatial.MbTiles.csproj" Type="Classic C#" />
     <Project Path="Spatial\src\Root\Wangkanai.Planet.Spatial.csproj" Type="Classic C#" />
     <File Path="Spatial\Directory.Build.props" />
     <File Path="Spatial\README.md" />

--- a/Spatial/src/Abstractions/Attribution.cs
+++ b/Spatial/src/Abstractions/Attribution.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Planet.Spatial;
+
+/// <summary>Represents an attribution with a name and a URL.</summary>
+/// <param name="Name">The name of the attribution.</param>
+/// <param name="Url">The URL of the attribution.</param>
+public record struct Attribution(string Name = "", string Url = "");

--- a/Spatial/src/Abstractions/Extent.cs
+++ b/Spatial/src/Abstractions/Extent.cs
@@ -2,7 +2,4 @@
 
 namespace Wangkanai.Planet.Spatial;
 
-public interface ILocalTileSource : ITileSource
-{
-	Task<byte[]?> GetTileAsync(TileInfo tileInfo);
-}
+public readonly struct Extent{}

--- a/Spatial/src/Abstractions/ILocalTileSource.cs
+++ b/Spatial/src/Abstractions/ILocalTileSource.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Planet.Spatial;
+
+public interface ILocalTileSource { }
+
+public interface ITileSource
+{
+	string      Name        { get; }
+	ITileSchema Schema      { get; }
+	Attribution Attribution { get; }
+}

--- a/Spatial/src/Abstractions/ITileSchema.cs
+++ b/Spatial/src/Abstractions/ITileSchema.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Planet.Spatial;
+
+/// <summary>Defines the schema for a tile.</summary>
+public interface ITileSchema
+{
+	/// <summary>Gets the name of the tile schema.</summary>
+	string Name { get; }
+}

--- a/Spatial/src/Abstractions/ITileSource.cs
+++ b/Spatial/src/Abstractions/ITileSource.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Planet.Spatial;
+
+/// <summary>Defines an interface for a tile source.</summary>
+public interface ITileSource
+{
+	/// <summary>Gets the name of the tile source.</summary>
+	string Name { get; }
+
+	/// <summary>Gets the schema for the tile source.</summary>
+	ITileSchema Schema { get; }
+
+	/// <summary>Gets the attribution information for the tile source.</summary>
+	Attribution Attribution { get; }
+}

--- a/Spatial/src/Abstractions/TileIndex.cs
+++ b/Spatial/src/Abstractions/TileIndex.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Wangkanai.Planet.Spatial;
+
+/// <summary>Represents a tile index with column, row, and level information.</summary>
+/// <param name="col">The column index.</param>
+/// <param name="row">The row index.</param>
+/// <param name="level">The level index.</param>
+public readonly struct TileIndex(int col, int row, int level) : IComparable
+{
+	public int Col   { get; } = col;
+	public int Row   { get; } = row;
+	public int Level { get; } = level;
+
+	/// <summary>Compares the current TileIndex with another TileIndex.</summary>
+	/// <param name="obj">The TileIndex to compare with.</param>
+	/// <returns>A value that indicates the relative order of the objects being compared.</returns>
+	/// <exception cref="ArgumentException">Thrown when the object to compare is not a TileIndex.</exception>
+	public int CompareTo(object? obj)
+	{
+		if (obj is not TileIndex index)
+			throw new ArgumentException("Object of type TileIndex was expected", nameof(obj));
+		return CompareTo(index);
+	}
+
+	/// <summary>Compares the current TileIndex with another TileIndex.</summary>
+	/// <param name="index">The TileIndex to compare with.</param>
+	/// <returns>A value that indicates the relative order of the objects being compared.</returns>
+	public int CompareTo(TileIndex index)
+	{
+		if (Col < index.Col) return -1;
+		if (Col > index.Col) return 1;
+		if (Row < index.Row) return -1;
+		if (Row > index.Row) return 1;
+		if (Level < index.Level) return -1;
+		if (Level > index.Level) return 1;
+		return 0;
+	}
+
+	/// <summary>Determines whether the specified object is equal to the current object.</summary>
+	/// <param name="obj">The object to compare with the current object.</param>
+	/// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
+	public override bool Equals([NotNullWhen(true)] object? obj)
+	{
+		if (obj is not TileIndex index)
+			return false;
+		return base.Equals(obj);
+	}
+
+	/// <summary>Determines whether the specified object is equal to the current object.</summary>
+	/// <param name="index">TileIndex instance to compare with</param>
+	/// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
+	public bool Equals(TileIndex index)
+		=> Col == index.Col && Row == index.Row && Level == index.Level;
+
+	/// <summary>Serves as a hash function for the TileIndex.</summary>
+	/// <returns>A hash code for the TileIndex.</returns>
+	public override int GetHashCode()
+		=> Col ^ Row ^ Level;
+
+	/// <summary>Determines if two TileIndex objects are equal.</summary>
+	/// <param name="left">The first TileIndex to compare.</param>
+	/// <param name="right">The second TileIndex to compare.</param>
+	/// <returns>true if the TileIndex objects are equal; otherwise, false.</returns>
+	public static bool operator ==(TileIndex left, TileIndex right)
+		=> Equals(left, right);
+
+	/// <summary>Determines if two TileIndex objects are not equal.</summary>
+	/// <param name="left">The first TileIndex to compare.</param>
+	/// <param name="right">The second TileIndex to compare.</param>
+	/// <returns>true if the TileIndex objects are not equal; otherwise, false.</returns>
+	public static bool operator !=(TileIndex left, TileIndex right)
+		=> !(left == right);
+
+	/// <summary>Determines if one TileIndex object is less than another.</summary>
+	/// <param name="left">The first TileIndex to compare.</param>
+	/// <param name="right">The second TileIndex to compare.</param>
+	/// <returns>true if the first TileIndex is less than the second; otherwise, false.</returns>
+	public static bool operator <(TileIndex left, TileIndex right)
+		=> left.CompareTo(right) < 0;
+
+	/// <summary>Determines if one TileIndex is greater than another.</summary>
+	/// <param name="left">The first TileIndex to compare.</param>
+	/// <param name="right">The second TileIndex to compare.</param>
+	/// <returns>true if the left TileIndex is greater than the right TileIndex; otherwise, false.</returns>
+	public static bool operator >(TileIndex left, TileIndex right)
+		=> left.CompareTo(right) > 0;
+}

--- a/Spatial/src/Abstractions/TileInfo.cs
+++ b/Spatial/src/Abstractions/TileInfo.cs
@@ -2,7 +2,8 @@
 
 namespace Wangkanai.Planet.Spatial;
 
-public interface ILocalTileSource : ITileSource
+public class TileInfo
 {
-	Task<byte[]?> GetTileAsync(TileInfo tileInfo);
+	public Extent    Extent { get; set; }
+	public TileIndex Index  { get; set; }
 }

--- a/Spatial/src/MbTiles/MbTileFormat.cs
+++ b/Spatial/src/MbTiles/MbTileFormat.cs
@@ -14,5 +14,5 @@ public enum MbTileFormat
 	/// <summary>WebP format</summary>
 	Webp,
 	/// <summary>Protobuf vector format</summary>
-	Pdf,
+	Pbf,
 }

--- a/Spatial/src/MbTiles/MbTileFormat.cs
+++ b/Spatial/src/MbTiles/MbTileFormat.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Planet.Spatial;
+
+/// <summary>Specifies the format of an MbTile.</summary>
+public enum MbTileFormat
+{
+	/// <summary>Portable Network Graphics (PNG)</summary>
+	Png,
+	/// <summary>Joint Photographic Experts Group (JPEG)</summary>
+	Jpg,
+	/// <summary>Joint Photographic Experts Group (JPEG)</summary>
+	Jpeg = Jpg,
+	/// <summary>WebP format</summary>
+	Webp,
+	/// <summary>Protobuf vector format</summary>
+	Pdf,
+}

--- a/Spatial/src/MbTiles/MbTileType.cs
+++ b/Spatial/src/MbTiles/MbTileType.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Planet.Spatial;
+
+/// <summary>Specifies the type of an MbTile.</summary>
+public enum MbTileType
+{
+	None,
+	BaseLayer,
+	Overlay
+}

--- a/Spatial/src/MbTiles/Wangkanai.Planet.Spatial.MbTiles.csproj
+++ b/Spatial/src/MbTiles/Wangkanai.Planet.Spatial.MbTiles.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This pull request introduces a new `MbTiles` project to the `Spatial` folder and adds several related abstractions and enumerations. These changes expand the functionality of the `Spatial` module by defining interfaces for tile schemas and sources, as well as enums for handling MbTile formats and types.

### Project Structure Updates:
* Added a new project, `Wangkanai.Planet.Spatial.MbTiles`, to the solution file `Planet.slnx` under the `Spatial` folder.
* Created a new project file, `Wangkanai.Planet.Spatial.MbTiles.csproj`, targeting `.NET 9.0` with nullable reference types and implicit usings enabled.

### New Abstractions:
* Introduced the `Attribution` record struct, which represents a name and URL for attribution purposes.
* Added the `ITileSource` interface, which defines properties for a tile source's name, schema, and attribution, along with the `ILocalTileSource` marker interface.
* Defined the `ITileSchema` interface, specifying a property for the name of a tile schema.

### Enumerations for MbTiles:
* Created the `MbTileFormat` enum to specify supported formats for MbTiles, including `Png`, `Jpg`, `Jpeg`, `Webp`, and `Pdf`.
* Added the `MbTileType` enum to define the type of an MbTile, such as `None`, `BaseLayer`, or `Overlay`.