### PR TITLE
Non-nullable property must contain a non-null value

### DIFF
--- a/Engine/src/Console/CommandLine/CommandLineApplication.cs
+++ b/Engine/src/Console/CommandLine/CommandLineApplication.cs
@@ -4,5 +4,5 @@ namespace Wangkanai.Planet.Engine.CommandLine;
 
 public class CommandLineApplication
 {
-	public string Name { get; set; }
+	public required string Name { get; set; }
 }

--- a/Portal/src/Domain/Identity/PlanetUser.cs
+++ b/Portal/src/Domain/Identity/PlanetUser.cs
@@ -6,8 +6,8 @@ namespace Wangkanai.Planet.Portal.Data;
 
 public class PlanetUser : IdentityUser<int>
 {
-	public string   Firstname { get; set; }
-	public string   Lastname  { get; set; }
-	public DateOnly Birthday  { get; set; }
-	public PlanetTheme    Theme     { get; set; }
+	public required string      Firstname { get; set; }
+	public required string      Lastname  { get; set; }
+	public          DateOnly    Birthday  { get; set; }
+	public          PlanetTheme Theme     { get; set; }
 }


### PR DESCRIPTION
This pull request introduces the use of the `required` modifier for properties in two classes to enforce initialization at object creation. These changes improve code safety by ensuring that critical properties cannot be left uninitialized.

### Changes to enforce required property initialization:

* `CommandLineApplication` class in `Engine/src/Console/CommandLine/CommandLineApplication.cs`: Updated the `Name` property to be `required`, ensuring it is always initialized when an instance of the class is created.
* `PlanetUser` class in `Portal/src/Domain/Identity/PlanetUser.cs`: Updated the `Firstname` and `Lastname` properties to be `required`, ensuring these essential user details are always provided during object initialization.