### PR TITLE
test: clean up whitespace in TiffRasterTests for improved readability

### DIFF
--- a/Drawing/Rasters/tests/Unit/Tiffs/TiffRasterTests.cs
+++ b/Drawing/Rasters/tests/Unit/Tiffs/TiffRasterTests.cs
@@ -12,7 +12,7 @@ public class TiffRasterTests
 	{
 		// Arrange & Act
 		var tiffRaster = new TiffRaster();
-		
+
 		// Assert
 		Assert.Equal(TiffColorDepth.TwentyFourBit, tiffRaster.ColorDepth);
 		Assert.Equal(TiffCompression.None, tiffRaster.Compression);
@@ -23,48 +23,48 @@ public class TiffRasterTests
 		Assert.Equal(1, tiffRaster.PlanarConfiguration);
 		Assert.NotNull(tiffRaster.Metadata);
 	}
-	
+
 	[Fact]
 	public void Constructor_WithDimensions_ShouldSetWidthAndHeight()
 	{
 		// Arrange
 		const int width = 1024;
 		const int height = 768;
-		
+
 		// Act
 		var tiffRaster = new TiffRaster(width, height);
-		
+
 		// Assert
 		Assert.Equal(width, tiffRaster.Width);
 		Assert.Equal(height, tiffRaster.Height);
 	}
-	
+
 	[Fact]
 	public void ColorDepth_CanBeModified()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
-		
+
 		// Act
 		tiffRaster.ColorDepth = TiffColorDepth.SixteenBit;
-		
+
 		// Assert
 		Assert.Equal(TiffColorDepth.SixteenBit, tiffRaster.ColorDepth);
 	}
-	
+
 	[Fact]
 	public void Compression_CanBeModified()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
-		
+
 		// Act
 		tiffRaster.Compression = TiffCompression.Lzw;
-		
+
 		// Assert
 		Assert.Equal(TiffCompression.Lzw, tiffRaster.Compression);
 	}
-	
+
 	[Fact]
 	public void Metadata_CanBeModified()
 	{
@@ -76,58 +76,58 @@ public class TiffRasterTests
 			Make = "Test Camera",
 			Model = "Test Model"
 		};
-		
+
 		// Act
 		tiffRaster.Metadata = metadata;
-		
+
 		// Assert
 		Assert.Equal("Test Image", tiffRaster.Metadata.ImageDescription);
 		Assert.Equal("Test Camera", tiffRaster.Metadata.Make);
 		Assert.Equal("Test Model", tiffRaster.Metadata.Model);
 	}
-	
+
 	[Fact]
 	public void SetBitsPerSample_WithArray_ShouldUpdateBitsPerSample()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
 		var newBitsPerSample = new[] { 16, 16, 16, 16 };
-		
+
 		// Act
 		tiffRaster.SetBitsPerSample(newBitsPerSample);
-		
+
 		// Assert
 		Assert.True(tiffRaster.BitsPerSample.SequenceEqual(newBitsPerSample));
 	}
-	
+
 	[Fact]
 	public void SetBitsPerSample_WithSpan_ShouldUpdateBitsPerSample()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
 		var newBitsPerSample = new[] { 32, 32 };
-		
+
 		// Act
 		tiffRaster.SetBitsPerSample(newBitsPerSample.AsSpan());
-		
+
 		// Assert
 		Assert.True(tiffRaster.BitsPerSample.SequenceEqual(newBitsPerSample));
 	}
-	
+
 	[Fact]
 	public void BitsPerSample_ShouldReturnReadOnlySpan()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
-		
+
 		// Act
 		var bitsPerSample = tiffRaster.BitsPerSample;
-		
+
 		// Assert
 		Assert.Equal(3, bitsPerSample.Length);
 		Assert.True(bitsPerSample.SequenceEqual(new[] { 8, 8, 8 }));
 	}
-	
+
 	[Theory]
 	[InlineData(new int[] { })]
 	[InlineData(new[] { 8 })]
@@ -140,55 +140,56 @@ public class TiffRasterTests
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
-		
+
 		// Act
 		tiffRaster.SetBitsPerSample(expected);
 		var actual = tiffRaster.BitsPerSample;
-		
+
 		// Assert
 		Assert.Equal(expected.Length, actual.Length);
 		Assert.True(actual.SequenceEqual(expected));
 	}
-	
+
 	[Fact]
 	public void BitsPerSample_WithInlineStorage_ShouldUseStackAllocation()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
 		var expected = new[] { 16, 16, 16 };
-		
+
 		// Act
 		tiffRaster.SetBitsPerSample(expected);
 		var actual = tiffRaster.BitsPerSample;
-		
+
 		// Assert - Verify behavior for inline storage (1-4 samples)
 		Assert.Equal(3, actual.Length);
 		Assert.True(actual.SequenceEqual(expected));
 	}
-	
+
 	[Fact]
 	public void BitsPerSample_WithLargeArray_ShouldFallbackToHeapAllocation()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
 		var expected = new[] { 8, 8, 8, 8, 8, 8, 8, 8, 8, 8 }; // More than 4 samples
-		
+
 		// Act
 		tiffRaster.SetBitsPerSample(expected);
 		var actual = tiffRaster.BitsPerSample;
-		
+
 		// Assert - Verify behavior for heap allocation (>4 samples)
 		Assert.Equal(10, actual.Length);
 		Assert.True(actual.SequenceEqual(expected));
 	}
-	
+
 	[Fact]
 	public void Dispose_ShouldNotThrow()
 	{
 		// Arrange
 		var tiffRaster = new TiffRaster();
-		
+
 		// Act & Assert
-		tiffRaster.Dispose();
+		var exception = Record.Exception(() => tiffRaster.Dispose());
+		Assert.Null(exception);
 	}
 }


### PR DESCRIPTION
This pull request updates the `Dispose_ShouldNotThrow` test in `TiffRasterTests.cs` to improve the reliability of the test by explicitly verifying that no exceptions are thrown during disposal.

* [`Drawing/Rasters/tests/Unit/Tiffs/TiffRasterTests.cs`](diffhunk://#diff-2df5db1068931f4bad5135c84334f4bac590ffb6a71ec86f17bf3f45c36706a3L192-R193): Modified the test to use `Record.Exception` to capture any exceptions thrown by `Dispose` and added an assertion to ensure the exception is null.