### PR TITLE
docs: add section on Memories and mention access to mcp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,7 @@ The Planet solution follows a modular architecture with these main components:
 - **Protocols/src/Root**: Protocol abstractions and WMS implementations
 - **Providers/Bing**: Bing Maps service integration
 - **Providers/Google**: Google Maps service integration
+
+## Memories
+
+- Claude Code now has access to mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,4 +120,4 @@ The Planet solution follows a modular architecture with these main components:
 
 ## Memories
 
-- Claude Code now has access to mcp
+- Claude Code now has access to MCP


### PR DESCRIPTION
This pull request updates the `CLAUDE.md` documentation to include a new section about "Memories," which describes Claude Code's access to MCP.

Documentation update:

* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R120-R123): Added a new section titled "Memories" to document Claude Code's access to MCP.