### PR TITLE
Refactor WebPConstants to use ImmutableArray for constant byte arrays

### DIFF
--- a/Graphics/Rasters/src/Root/WebPs/WebPConstants.cs
+++ b/Graphics/Rasters/src/Root/WebPs/WebPConstants.cs
@@ -1,42 +1,44 @@
 // Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
 
+using System.Collections.Immutable;
+
 namespace Wangkanai.Graphics.Rasters.WebPs;
 
 /// <summary>Defines constants for WebP format specifications.</summary>
 public static class WebPConstants
 {
 	/// <summary>The WebP signature bytes (RIFF header).</summary>
-	public static readonly byte[] Signature = "RIFF"u8.ToArray();
+	public static readonly ImmutableArray<byte> Signature = "RIFF"u8.ToImmutableArray();
 
 	/// <summary>The WebP format identifier.</summary>
-	public static readonly byte[] FormatId = "WEBP"u8.ToArray();
+	public static readonly ImmutableArray<byte> FormatId = "WEBP"u8.ToImmutableArray();
 
 	/// <summary>The VP8 chunk identifier for lossy compression.</summary>
-	public static readonly byte[] VP8ChunkId = "VP8 "u8.ToArray();
+	public static readonly ImmutableArray<byte> VP8ChunkId = "VP8 "u8.ToImmutableArray();
 
 	/// <summary>The VP8L chunk identifier for lossless compression.</summary>
-	public static readonly byte[] VP8LChunkId = "VP8L"u8.ToArray();
+	public static readonly ImmutableArray<byte> VP8LChunkId = "VP8L"u8.ToImmutableArray();
 
 	/// <summary>The VP8X chunk identifier for extended features.</summary>
-	public static readonly byte[] VP8XChunkId = "VP8X"u8.ToArray();
+	public static readonly ImmutableArray<byte> VP8XChunkId = "VP8X"u8.ToImmutableArray();
 
 	/// <summary>The ALPH chunk identifier for alpha channel.</summary>
-	public static readonly byte[] AlphaChunkId = "ALPH"u8.ToArray();
+	public static readonly ImmutableArray<byte> AlphaChunkId = "ALPH"u8.ToImmutableArray();
 
 	/// <summary>The ANIM chunk identifier for animation.</summary>
-	public static readonly byte[] AnimChunkId = "ANIM"u8.ToArray();
+	public static readonly ImmutableArray<byte> AnimChunkId = "ANIM"u8.ToImmutableArray();
 
 	/// <summary>The ANMF chunk identifier for animation frames.</summary>
-	public static readonly byte[] AnimFrameChunkId = "ANMF"u8.ToArray();
+	public static readonly ImmutableArray<byte> AnimFrameChunkId = "ANMF"u8.ToImmutableArray();
 
 	/// <summary>The ICCP chunk identifier for ICC profile.</summary>
-	public static readonly byte[] IccProfileChunkId = "ICCP"u8.ToArray();
+	public static readonly ImmutableArray<byte> IccProfileChunkId = "ICCP"u8.ToImmutableArray();
 
 	/// <summary>The EXIF chunk identifier for EXIF metadata.</summary>
-	public static readonly byte[] ExifChunkId = "EXIF"u8.ToArray();
+	public static readonly ImmutableArray<byte> ExifChunkId = "EXIF"u8.ToImmutableArray();
 
 	/// <summary>The XMP chunk identifier for XMP metadata.</summary>
-	public static readonly byte[] XmpChunkId = "XMP "u8.ToArray();
+	public static readonly ImmutableArray<byte> XmpChunkId = "XMP "u8.ToImmutableArray();
 
 	/// <summary>The minimum width for WebP images.</summary>
 	public const uint MinWidth = 1;

--- a/Graphics/Rasters/src/Root/WebPs/WebPValidator.cs
+++ b/Graphics/Rasters/src/Root/WebPs/WebPValidator.cs
@@ -209,11 +209,11 @@ public static class WebPValidator
 			return false;
 
 		// Check RIFF header
-		if (!data[..4].SequenceEqual(WebPConstants.Signature))
+		if (!data[..4].SequenceEqual(WebPConstants.Signature.AsSpan()))
 			return false;
 
 		// Check WEBP format identifier
-		return data.Slice(8, 4).SequenceEqual(WebPConstants.FormatId);
+		return data.Slice(8, 4).SequenceEqual(WebPConstants.FormatId.AsSpan());
 	}
 
 	/// <summary>Gets the WebP format type from file data.</summary>
@@ -229,13 +229,13 @@ public static class WebPValidator
 
 		var chunkId = data.Slice(WebPConstants.RiffHeaderSize, 4);
 
-		if (chunkId.SequenceEqual(WebPConstants.VP8ChunkId))
+		if (chunkId.SequenceEqual(WebPConstants.VP8ChunkId.AsSpan()))
 			return WebPFormat.Simple;
 
-		if (chunkId.SequenceEqual(WebPConstants.VP8LChunkId))
+		if (chunkId.SequenceEqual(WebPConstants.VP8LChunkId.AsSpan()))
 			return WebPFormat.Lossless;
 
-		if (chunkId.SequenceEqual(WebPConstants.VP8XChunkId))
+		if (chunkId.SequenceEqual(WebPConstants.VP8XChunkId.AsSpan()))
 			return WebPFormat.Extended;
 
 		return WebPFormat.Simple;


### PR DESCRIPTION
This pull request refactors the `WebPConstants` class to use `ImmutableArray<byte>` instead of `byte[]` for defining WebP format constants, ensuring immutability and improving performance in scenarios involving frequent reads. Corresponding updates were made to methods in `WebPValidator` to accommodate this change.

### Refactoring for immutability:

* [`Graphics/Rasters/src/Root/WebPs/WebPConstants.cs`](diffhunk://#diff-32828411ed19f882bbd47ff01078aaa60c451baf2c1658b499229a65e1cedb7eR3-R41): Replaced all `byte[]` fields with `ImmutableArray<byte>` for WebP format constants to enhance immutability and performance.

### Method updates to support `ImmutableArray<byte>`:

* [`Graphics/Rasters/src/Root/WebPs/WebPValidator.cs`](diffhunk://#diff-bd1171ce16324eb3eb4ac07ee6b4bd6882bcab0a109140b4e5c63c8f9eb1eef0L212-R216): Updated `IsValidWebPSignature` method to use `AsSpan()` for comparing `ImmutableArray<byte>` constants with `ReadOnlySpan<byte>` data.
* [`Graphics/Rasters/src/Root/WebPs/WebPValidator.cs`](diffhunk://#diff-bd1171ce16324eb3eb4ac07ee6b4bd6882bcab0a109140b4e5c63c8f9eb1eef0L232-R238): Updated `DetectFormat` method to use `AsSpan()` for detecting WebP format types based on `ImmutableArray<byte>` constants.