### PR TITLE
refactor: Change Raster class to abstract and simplify Dispose logic

### DIFF
--- a/Graphics/Rasters/src/Root/Raster.cs
+++ b/Graphics/Rasters/src/Root/Raster.cs
@@ -3,7 +3,7 @@
 namespace Wangkanai.Graphics.Rasters;
 
 /// <summary>Represents a raster image</summary>
-public class Raster : IRaster
+public abstract class Raster : IRaster
 {
 	private bool _disposed;
 
@@ -42,30 +42,14 @@ public class Raster : IRaster
 
 	/// <summary>Releases the managed and unmanaged resources used by the raster image.</summary>
 	/// <param name="disposing">
-	/// true to release both managed and unmanaged resources; 
+	/// true to release both managed and unmanaged resources;
 	/// false to release only unmanaged resources.
 	/// </param>
 	protected virtual void Dispose(bool disposing)
 	{
-		if (!_disposed)
-		{
-			if (disposing)
-			{
-				// Dispose managed resources here
-				// Derived classes should override this method to dispose their specific resources
-			}
-
-			// Dispose unmanaged resources here if any
-			// This should be done regardless of the disposing parameter
-
-			_disposed = true;
-		}
-	}
-
-	/// <summary>Throws an ObjectDisposedException if the object has been disposed.</summary>
-	protected void ThrowIfDisposed()
-	{
 		if (_disposed)
-			throw new ObjectDisposedException(GetType().Name);
+			return;
+
+		_disposed = true;
 	}
 }


### PR DESCRIPTION
This pull request refactors the `Raster` class in `Graphics/Rasters/src/Root/Raster.cs` to improve its design and resource management. The key changes include making the class abstract and simplifying the disposal logic.

### Class design improvements:
* Changed `Raster` from a concrete class to an abstract class to better reflect its intended usage as a base class for other raster image implementations. (`[Graphics/Rasters/src/Root/Raster.csL6-R6](diffhunk://#diff-79596a9286bb4ca375882a559cbd02b23f1e2e324c0ac482c5dc44ede8d34caeL6-R6)`)

### Resource disposal improvements:
* Simplified the `Dispose` method logic by removing redundant checks and comments, making the code cleaner and easier to maintain. (`[Graphics/Rasters/src/Root/Raster.csL50-L71](diffhunk://#diff-79596a9286bb4ca375882a559cbd02b23f1e2e324c0ac482c5dc44ede8d34caeL50-L71)`)
* Removed the `ThrowIfDisposed` method, which was previously used to throw exceptions if the object was disposed, as it is no longer necessary in the updated design. (`[Graphics/Rasters/src/Root/Raster.csL50-L71](diffhunk://#diff-79596a9286bb4ca375882a559cbd02b23f1e2e324c0ac482c5dc44ede8d34caeL50-L71)`)